### PR TITLE
nestjs-rest-api: Fix book model typo

### DIFF
--- a/components/nestjs-rest-api/src/modules/book/book.model.ts
+++ b/components/nestjs-rest-api/src/modules/book/book.model.ts
@@ -17,7 +17,7 @@ export const Book = new Schema({
   },
 });
 
-Book.set('toJSON', {
+Book.set("toJSON", {
   virtuals: true
 });
 

--- a/components/nestjs-rest-api/src/modules/book/book.model.ts
+++ b/components/nestjs-rest-api/src/modules/book/book.model.ts
@@ -6,7 +6,7 @@ import { Schema, Document } from "mongoose";
 export const Book = new Schema({
   title: { type: String, required: true },
   description: { type: String, required: false, default: null },
-  availabe: { type: Boolean, required: false, default: true },
+  available: { type: Boolean, required: false, default: true },
   createdAt: {
     type: Date,
     default: Date.now,


### PR DESCRIPTION
The book model had a typo

`available` was misspelt as `availabe` 

So db and API response carried it too.