### PR TITLE
fixes the backend URL for the Angular front end

### DIFF
--- a/.bunnyshell/templates/express-angular-postgres/bunnyshell.yaml
+++ b/.bunnyshell/templates/express-angular-postgres/bunnyshell.yaml
@@ -60,7 +60,7 @@ components:
                     reservations:
                         memory: 1G
             environment:
-                API_URL: 'https://{{ components.api.ingress.hosts[0] }}'
+                API_URL: 'https://{{ components.api.ingress.hosts[0].hostname }}'
             labels:
                 kompose.service.healthcheck.readiness.test: 'CMD sh -c "wget --no-verbose --tries=1 --spider http://127.0.0.1:8080 || exit 1"'
                 kompose.service.healthcheck.readiness.interval: 15s


### PR DESCRIPTION
fixes the backend URL for the Angular front end.
Without this, the FE posts to //books and the request fails