### PR TITLE
update, fix Magento templates

### DIFF
--- a/.bunnyshell/templates/magento-dev/README.md
+++ b/.bunnyshell/templates/magento-dev/README.md
@@ -8,9 +8,15 @@ An [Environment in Bunnyshell](https://documentation.bunnyshell.com/docs/environ
 
 ## Template specifics
 
-In order to download Magento, you will need to fill in the Magento keys, which you can get from your Adobe account:
+### Magento Keys !!
+Adobe requires a developer account to be able to install Magento.
+In order for the environment to successfully deploy, you MUST fill in this Magento auth secret variables with the values from your Adobe account:
 - `MAGE_PRIVKEY`
 - `MAGE_PUBKEY`
+
+### ElasticSearch Resources
+Elasticsearch is configured to use 1GB of RAM. Edit the environment yaml ( `resources` section of the `elasticsearch` component) to set a different value.
+
 
 &nbsp;
 

--- a/.bunnyshell/templates/magento-dev/bunnyshell.yaml
+++ b/.bunnyshell/templates/magento-dev/bunnyshell.yaml
@@ -22,8 +22,8 @@ environmentVariables:
   MAGE_INIT_PARAMS: MAGE_MODE=developer
   MAGE_KEY: abcdefghijklmnopqrstuvwxyzABCDEF
   MAGE_LANGUAGE: en_US
-  MAGE_PRIVKEY: replace-with-your-credentials
-  MAGE_PUBKEY: replace-with-your-credentials
+  MAGE_PRIVKEY: '{{ template.vars.MAGE_PRIVKEY }}'
+  MAGE_PUBKEY: '{{ template.vars.MAGE_PUBKEY }}'
   MAGE_SEARCH_ENGINE: elasticsearch7
   MAGE_TIMEZONE: Europe/Bucharest
   MAGE_USE_REWRITES: '1'

--- a/.bunnyshell/templates/magento-dev/bunnyshell.yaml
+++ b/.bunnyshell/templates/magento-dev/bunnyshell.yaml
@@ -118,7 +118,7 @@ components:
         MYSQL_PASSWORD: magento2
         MYSQL_ROOT_PASSWORD: magento2
         MYSQL_USER: magento2
-      image: 'mysql:8'
+      image: 'mysql:8.0'
       ports:
         - '3306:3306'
     volumes:
@@ -134,6 +134,14 @@ components:
         cluster.name: es-docker
         node.name: node1
       image: 'magento/magento-cloud-docker-elasticsearch:7.11-1.3.2'
+      deploy:
+        resources:
+          limits:
+            cpus: '1'
+            memory: 1G
+          reservations:
+            cpus: '0.50'
+            memory: 1G
       ports:
         - '9200:9200'
     volumes:

--- a/.bunnyshell/templates/magento-dev/template.yaml
+++ b/.bunnyshell/templates/magento-dev/template.yaml
@@ -20,3 +20,10 @@ stack:
     - name: Varnish
       version: '7.1'
 discoverable: true
+variables:
+  - description: 'Magento Private Key'
+    name: 'MAGE_PRIVKEY'
+    type: 'string'
+  - description: 'Magento Public Key'
+    name: 'MAGE_PUBKEY'
+    type: 'string'    

--- a/.bunnyshell/templates/magento-prod/README.md
+++ b/.bunnyshell/templates/magento-prod/README.md
@@ -8,9 +8,14 @@ An [Environment in Bunnyshell](https://documentation.bunnyshell.com/docs/environ
 
 ## Template specifics
 
-In order to download Magento, you will need to fill in the Magento keys, which you can get from your Adobe account:
+### Magento Keys !!
+Adobe requires a developer account to be able to install Magento.
+In order for the environment to successfully deploy, you MUST fill in this Magento auth secret variables with the values from your Adobe account:
 - `MAGE_PRIVKEY`
 - `MAGE_PUBKEY`
+
+### ElasticSearch Resources
+Elasticsearch is configured to use 1GB of RAM. Edit the environment yaml ( `resources` section of the `elasticsearch` component) to set a different value.
 
 &nbsp;
 

--- a/.bunnyshell/templates/magento-prod/bunnyshell.yaml
+++ b/.bunnyshell/templates/magento-prod/bunnyshell.yaml
@@ -237,7 +237,7 @@ components:
         MYSQL_PASSWORD: magento2
         MYSQL_ROOT_PASSWORD: magento2
         MYSQL_USER: magento2
-      image: 'mysql:8'
+      image: 'mysql:8.0'
       ports:
         - '3306:3306'
     volumes:
@@ -253,6 +253,14 @@ components:
         cluster.name: es-docker
         node.name: node1
       image: 'magento/magento-cloud-docker-elasticsearch:7.11-1.3.2'
+      deploy:
+        resources:
+          limits:
+            cpus: '1'
+            memory: 1G
+          reservations:
+            cpus: '0.50'
+            memory: 1G
       ports:
         - '9200:9200'
     volumes:

--- a/.bunnyshell/templates/magento-prod/bunnyshell.yaml
+++ b/.bunnyshell/templates/magento-prod/bunnyshell.yaml
@@ -22,8 +22,8 @@ environmentVariables:
   MAGE_INIT_PARAMS: MAGE_MODE=developer
   MAGE_KEY: abcdefghijklmnopqrstuvwxyzABCDEF
   MAGE_LANGUAGE: en_US
-  MAGE_PRIVKEY: replace-with-your-credentials
-  MAGE_PUBKEY: replace-with-your-credentials
+  MAGE_PRIVKEY: '{{ template.vars.MAGE_PRIVKEY }}'
+  MAGE_PUBKEY: '{{ template.vars.MAGE_PUBKEY }}'
   MAGE_SEARCH_ENGINE: elasticsearch7
   MAGE_TIMEZONE: Europe/Bucharest
   MAGE_USE_REWRITES: '1'

--- a/.bunnyshell/templates/magento-prod/template.yaml
+++ b/.bunnyshell/templates/magento-prod/template.yaml
@@ -20,3 +20,10 @@ stack:
     - name: Varnish
       version: '7.1'
 discoverable: true
+variables:
+  - description: 'Magento Private Key'
+    name: 'MAGE_PRIVKEY'
+    type: 'string'
+  - description: 'Magento Public Key'
+    name: 'MAGE_PUBKEY'
+    type: 'string'  


### PR DESCRIPTION
- Adds template variables for Adobe authentication.
- pins mysql to 8.0 (because 8 is now 8.4 and is not supported by Magento)
- adds resource limits for Elasticsearch (to prevent high RAM usage)